### PR TITLE
Add link to latest Brick build

### DIFF
--- a/webpages/resources.md
+++ b/webpages/resources.md
@@ -155,4 +155,4 @@ Memoori 2019
 [25]: /papers/WhoWhatWhen-BuildSys-2019-Koh.pdf
 [26]: /papers/Advanced-Engineering-Informatics-2018-Gao.pdf
 [27]: /schema/1.1/Brick.ttl
-[28]: https://github.com/BrickSchema/Brick/releases/latest
+[28]: https://github.com/BrickSchema/Brick/releases/download/nightly/Brick.ttl

--- a/webpages/resources.md
+++ b/webpages/resources.md
@@ -15,7 +15,7 @@ Turtle is a compact textual format that is understood by most Semantic Web tools
    - [Brick.ttl][27]: Brick classes and tagsets
 
 - **Latest Build**:
-   - [Brick.ttl][28]: The most recent build of Brick as of 2am UTC every day. Contains the latest changes, but also the latest bugs. Helpful for development
+   - [Brick.ttl][28]: The most recent build of Brick as of 2am UTC every day. Contains the latest changes, but also the latest bugs. Helpful for development; for stability, use the stable version linked above.
 
 - **Old Version (1.0.3) -- Not supported**:
    - [Brick.ttl][1]: Brick classes and tagsets

--- a/webpages/resources.md
+++ b/webpages/resources.md
@@ -14,6 +14,8 @@ Turtle is a compact textual format that is understood by most Semantic Web tools
 - **Latest Version (1.1.0)**:
    - [Brick.ttl][27]: Brick classes and tagsets
 
+- **Latest Build**:
+   - [Brick.ttl][28]: The latest committed version of Brick. Contains the latest changes, but also the latest bugs
 
 - **Old Version (1.0.3) -- Not supported**:
    - [Brick.ttl][1]: Brick classes and tagsets
@@ -153,3 +155,4 @@ Memoori 2019
 [25]: /papers/WhoWhatWhen-BuildSys-2019-Koh.pdf
 [26]: /papers/Advanced-Engineering-Informatics-2018-Gao.pdf
 [27]: /schema/1.1/Brick.ttl
+[28]: https://raw.githubusercontent.com/BrickSchema/Brick/master/Brick.ttl

--- a/webpages/resources.md
+++ b/webpages/resources.md
@@ -11,11 +11,11 @@ show_on_navbar: true
 The Brick ontology is distributed as a set of [Turtle][15] files.
 Turtle is a compact textual format that is understood by most Semantic Web tools.
 
-- **Latest Version (1.1.0)**:
+- **Latest Stable Version (1.1.0)**:
    - [Brick.ttl][27]: Brick classes and tagsets
 
 - **Latest Build**:
-   - [Brick.ttl][28]: The latest committed version of Brick. Contains the latest changes, but also the latest bugs
+   - [Brick.ttl][28]: The most recent build of Brick as of 2am UTC every day. Contains the latest changes, but also the latest bugs. Helpful for development
 
 - **Old Version (1.0.3) -- Not supported**:
    - [Brick.ttl][1]: Brick classes and tagsets
@@ -155,4 +155,4 @@ Memoori 2019
 [25]: /papers/WhoWhatWhen-BuildSys-2019-Koh.pdf
 [26]: /papers/Advanced-Engineering-Informatics-2018-Gao.pdf
 [27]: /schema/1.1/Brick.ttl
-[28]: https://raw.githubusercontent.com/BrickSchema/Brick/master/Brick.ttl
+[28]: https://github.com/BrickSchema/Brick/releases/latest


### PR DESCRIPTION
Should eventually have a nightly build of the Brick master branch that actually creates the TTL file and tags it; this is just prototyping how to display this on the page.