### PR TITLE
Add Docs link to navbar

### DIFF
--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -19,9 +19,6 @@
                     <li class="mr-8 mb-6 lg:mb-0">
                         <search-input />
                     </li>
-                    <li class="mr-8 mb-6 lg:mb-0">
-                        <g-link to="/#home" class="text-copy-primary hover:text-primary-700">Home</g-link>
-                    </li>
 
                     <li class="mr-8 mb-6 lg:mb-0">
                         <a href="https://docs.brickschema.org" class="text-copy-primary hover:text-primary-700 truncate">Docs</a>

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -23,6 +23,10 @@
                         <g-link to="/#home" class="text-copy-primary hover:text-primary-700">Home</g-link>
                     </li>
 
+                    <li class="mr-8 mb-6 lg:mb-0">
+                        <a href="https://docs.brickschema.org" class="text-copy-primary hover:text-primary-700 truncate">Docs</a>
+                    </li>
+
                     <li class="mr-8 mb-6 lg:mb-0" v-for="webpage in $static.webpages.edges" :key="webpage.path" >
                         <g-link :to="webpage.node.path" class="text-copy-primary hover:text-primary-700 truncate">{{webpage.node.title}}</g-link>
                     </li>


### PR DESCRIPTION
Wasn't sure if this was the best way to add the link; the `<g-link>` tag wants to make everything relative, so I had to use `<a>`. Also wasn't sure how to interpose the `Docs` link in the navbar after the `Get Started` page, so I placed it before. Let me know if there's anything I can do to fix up the implementation