### PR TITLE
Add link to public roadmap

### DIFF
--- a/webpages/get-started.md
+++ b/webpages/get-started.md
@@ -11,6 +11,8 @@ The [Concepts page](/concepts) presents an overview of core concepts of Brick.
 
 The [Relationships memo](/relationships) provides some guidance and documentation on how to use Brick relationships.
 
+The [Public Roadmap](http://roadmap.brickschema.org/) outlines the near-term and long-term features of Brick that are under development.
+
 ### Exploring existing Brick models
 
 - **Observe** Brick models for 6 real buildings using the [BrickViewer tool](http://viewer.brickschema.org/)


### PR DESCRIPTION
Currently this is on the "Get Started" page; is there a more prominent location we can put it?