### PR TITLE
Add Working Group times to website

### DIFF
--- a/blog/working-groups.md
+++ b/blog/working-groups.md
@@ -1,0 +1,20 @@
+---
+title: Working Groups
+path: /blog/working-groups
+date: 2021-03-24
+summary: Brick Working Groups
+tags: ['brick', 'working', 'group', 'consortium']
+---
+
+As part of the [Brick Consortium](/consortium), a set of working groups have been established to organize community contributions and feedback around different aspects of the Brick ontology.
+There are two meetings of each working group: one in the morning (Pacific) and one in the evening (Pacific) so that there is a reasonable time to join for most parts of the world. These times alternate every other week, but the same agenda will be covered at each meeting, so there is only need to show up to one of the two.
+
+Two working groups have been launched:
+
+- **Ontology Development Working Group**: this working group discusses additions, extensions and fixes to the Brick ontology definition. This includes, but is not limited to, new classes, modeling domains, changes to the ontology structure, and documentation for Brick.
+    - Every two weeks starting Tuesday, March 9: 3:00 - 4:00pm Pacific Time on [Google Meet](https://meet.google.com/zev-myen-kxa)
+    - Every two weeks starting Thursday, March 18: 10:00 - 11:00am Pacific Time on [Google Meet](https://meet.google.com/fix-sfgf-qhk)
+
+- **Tooling Working Group**: this working group develops, tests and documents open-source software that facilitates use of Brick. This includes software for producing Brick models from existing representations and software/libraries/databases for  querying, managing and storing Brick models.
+    - Every two weeks starting Monday, March 15: 9:00 - 10:00am Pacific Time on [Google Meet](https://meet.google.com/jag-ibzk-xiy)
+    - Every two weeks Tuesday, March 9: 4:00 - 5:00pm Pacific Time on [Google Meet](https://meet.google.com/uzq-vnsv-icr)

--- a/webpages/get-started.md
+++ b/webpages/get-started.md
@@ -39,6 +39,8 @@ The [Public Roadmap](http://roadmap.brickschema.org/) outlines the near-term and
 
 **[Website Issue Tracker][6]**: The Website GitHub issues page is intended for discussing and proposing changes to the [Brick website][7]. Posting requires the creaion of a free Github account.
 
+**[Working Groups][12]**: Brick developments are organized through a set of working groups which meet every week at internationally-friendly times.
+
 ---
 
 ## Brick Tutorials
@@ -64,3 +66,4 @@ Several tutorials have been developed for Brick and its related tools.
 [9]: http://buildsys.acm.org/2017/tutorial/
 [10]: https://docs.google.com/presentation/d/14dxGyYBYzdweKZRSR3GLCAyR7VS9KqZeD6BWdBUQwt0/edit?usp=sharing
 [11]: https://energy.acm.org/conferences/eenergy/2019/tutorial.php
+[12]: /blog/working-groups


### PR DESCRIPTION
Duplicates most of the info from the Google Group post into a place that is easier to find and use as a reference