### PR TITLE
update working group schedule to combine tooling and data

### DIFF
--- a/blog/working-groups.md
+++ b/blog/working-groups.md
@@ -8,21 +8,17 @@ tags: ['brick', 'working', 'group', 'consortium']
 
 As part of the [Brick Consortium](/consortium), a set of working groups have been established to organize community contributions and feedback around different aspects of the Brick ontology.
 There are two meetings of each working group: one in the morning (Pacific) and one in the evening (Pacific) so that there is a reasonable time to join for most parts of the world. We aim to cover the same agenda for the group at each meeting, so there is only need to attend one of the two, so please pick the meeting that is most comfortable for your time zone.
+We are not strict about the content, so if you have an ontology question during a tooling timeslot, don't be afraid to come and ask it.
 
-The three working groups are:
+The two working groups are:
 
 - **Ontology Development Working Group**: this working group discusses additions, extensions and fixes to the Brick ontology definition. This includes, but is not limited to, new classes, modeling domains, changes to the ontology structure, and documentation for Brick.
     - Every second Wednesday, from 6:00 - 7:00 PM, Pacific Time on [Zoom](https://mines.zoom.us/j/96983354945?pwd=cGJ5OWpTRnplandlOFQyd2tKWXB1UT09)
     - Every third Thursday, from 10:00 - 11:00 AM, Pacific Time on [Zoom](https://mines.zoom.us/j/96983354945?pwd=cGJ5OWpTRnplandlOFQyd2tKWXB1UT09)
 
-- **Tooling Working Group**: this working group develops, tests and documents open-source software that facilitates use of Brick. This includes software for producing Brick models from existing representations and software/libraries/databases for  querying, managing and storing Brick models.
+- **Tooling and Data Working Group**: The tooling group develops, tests and documents open-source software that facilitates use of Brick.  This includes software for producing Brick models from existing representations and software/libraries/databases for  querying, managing and storing Brick models.  For data, the group also gathers, develops and documents example Brick models (both for full buildings as well as individual systems) and building data sets that can inform research and illustrate idiomatic use of Brick.
     - Every first Monday, from 9:00 - 10:00 AM, Pacific Time on [Zoom](https://mines.zoom.us/j/96983354945?pwd=cGJ5OWpTRnplandlOFQyd2tKWXB1UT09)
-    - Every fourth Tuesday, from 4:30 - 5:30 PM, Pacific Time on [Zoom](https://mines.zoom.us/j/96983354945?pwd=cGJ5OWpTRnplandlOFQyd2tKWXB1UT09)
-
-- **Data Working Group**: this working group gathers, develops and documents example Brick models (both for full buildings as well as individual systems) and building data sets that can inform research and illustrate idiomatic use of Brick.
-    - Every second Wednesday, from 5:00 - 6:00 PM, Pacific Time on [Zoom](https://mines.zoom.us/j/96983354945?pwd=cGJ5OWpTRnplandlOFQyd2tKWXB1UT09)
-    - Every third Monday, from 8:00 - 9:00 AM, Pacific Time on [Zoom](https://mines.zoom.us/j/96983354945?pwd=cGJ5OWpTRnplandlOFQyd2tKWXB1UT09)
-
+    - Every fourth Tuesday, from 5:00 - 6:00 PM, Pacific Time on [Zoom](https://mines.zoom.us/j/96983354945?pwd=cGJ5OWpTRnplandlOFQyd2tKWXB1UT09)
 
 ## Google Calendar
 


### PR DESCRIPTION
Update the descriptions to combine the two working groups. the gcal is externally managed and already has the updates applied.