### PR TITLE
Add support for Turtle/SPARQL code blocks

### DIFF
--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -123,7 +123,7 @@ module.exports = {
       anchorClassName: 'icon icon-link',
       plugins: [
         ['remark-attr'],
-        [ 'gridsome-plugin-remark-shiki', { theme: 'Material-Theme-Palenight', skipInline: true } ],
+        [ '@gridsome/remark-prismjs', { transformInlineCode: false } ],
         ['gridsome-plugin-remark-youtube', {width: '85%', align: 'auto'}],
       ]
     }

--- a/ontologyPages/v1.1.md
+++ b/ontologyPages/v1.1.md
@@ -51,7 +51,7 @@ The equivalency of a class to a set of tags is accomplished by modeling a Brick 
 
 Here is the Brick "class-to-tag" mapping definition for the `Temperature_Sensor` class:
 
-```xml
+```turtle
 # in turtle format
 brick:Temperature_Sensor a owl:Class ;
     rdfs:subClassOf brick:Sensor ;
@@ -75,7 +75,7 @@ brick:Temperature_Sensor a owl:Class ;
 The first `owl:Restriction` is the set of all classes that have `tag:Sensor` as the value for one of their `brick:hasTag` properties.
 Through a reasoning process, all instances of `brick:Temperature_Sensor` will inherit the tag annotations.
 
-```xml
+```turtle
 # input Brick model has an instance of brick:Temperature_Sensor
 :ts1   a   brick:Temperature_Sensor
 
@@ -90,7 +90,7 @@ To perform the inference of a class from a set of tags (the inverse of the proce
 
 For a sample entity modeled with tags:
 
-```xml
+```turtle
 # myfile.ttl
 @prefix brick: <https://brickschema.org/schema/1.1.0/Brick#> .
 @prefix tag: <https://brickschema.org/schema/1.1.0/BrickTag#> .
@@ -119,7 +119,7 @@ Substances and quantities can be related to equipment and points.
 Not all of this is implemented. In the current prototype, sensors are related to substances and quantities
 through the `brick:measures` relationship.
 
-```xml
+```turtle
 :ts1    a       brick:Temperature_Sensor
 :ts1    brick:measures      :Air
 
@@ -129,7 +129,7 @@ through the `brick:measures` relationship.
 
 We can further subclass substances to provide system- or process-level context to their definitions:
 
-```xml
+```turtle
 :ts1    a       brick:Sensor
 :ts1    brick:measures      brick:Return_Air
 :ts1    brick:measures      brick:Temperature
@@ -144,7 +144,7 @@ For this example, because `:ts1` measures Air (specifically the `brick:Air` clas
 
 Here's what that the definition looks like in turtle:
 
-```xml
+```turtle
 brick:Air_Temperature_Sensor a owl:Class ;
     rdfs:subClassOf brick:Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1028,6 +1028,58 @@
         "sitemap": "^2.1.0"
       }
     },
+    "@gridsome/remark-prismjs": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@gridsome/remark-prismjs/-/remark-prismjs-0.5.0.tgz",
+      "integrity": "sha512-aEQg/MTNOtsWC11yozSGJI51Qk+vG7pPAipULBryjmmmLq81IGFREkEXYXPLLVCib0D652a3/CrUBnTYQBuoWA==",
+      "requires": {
+        "escape-html": "^1.0.3",
+        "hast-util-to-html": "^6.0.2",
+        "hastscript": "^5.1.0",
+        "prismjs": "^1.15.0",
+        "unist-builder": "^1.0.4",
+        "unist-util-visit": "^1.4.0"
+      },
+      "dependencies": {
+        "hast-util-to-html": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-6.1.0.tgz",
+          "integrity": "sha512-IlC+LG2HGv0Y8js3wqdhg9O2sO4iVpRDbHOPwXd7qgeagpGsnY49i8yyazwqS35RA35WCzrBQE/n0M6GG/ewxA==",
+          "requires": {
+            "ccount": "^1.0.0",
+            "comma-separated-tokens": "^1.0.1",
+            "hast-util-is-element": "^1.0.0",
+            "hast-util-whitespace": "^1.0.0",
+            "html-void-elements": "^1.0.0",
+            "property-information": "^5.2.0",
+            "space-separated-tokens": "^1.0.0",
+            "stringify-entities": "^2.0.0",
+            "unist-util-is": "^3.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "property-information": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
+          "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
+          "requires": {
+            "xtend": "^4.0.0"
+          }
+        },
+        "stringify-entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-2.0.0.tgz",
+          "integrity": "sha512-fqqhZzXyAM6pGD9lky/GOPq6V4X0SeTAFBl0iXb/BzOegl40gpf/bV3QQP7zULNYvjr6+Dx8SCaDULjVoOru0A==",
+          "requires": {
+            "character-entities-html4": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-decimal": "^1.0.2",
+            "is-hexadecimal": "^1.0.0"
+          }
+        }
+      }
+    },
     "@gridsome/source-filesystem": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/@gridsome/source-filesystem/-/source-filesystem-0.6.2.tgz",
@@ -5582,16 +5634,6 @@
         }
       }
     },
-    "gridsome-plugin-remark-shiki": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/gridsome-plugin-remark-shiki/-/gridsome-plugin-remark-shiki-0.3.0.tgz",
-      "integrity": "sha512-W4RHQQknqIX4jKGhADKPqxxpPOEAqHlWOYmmupCv9bwgtyowWdPzi7OmVqUbOQU9ikcvPMrF07U9VLo74f7MTA==",
-      "requires": {
-        "shiki": "^0.1.2",
-        "shiki-languages": "^0.1.0",
-        "unist-util-visit": "^1.4.0"
-      }
-    },
     "gridsome-plugin-remark-youtube": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gridsome-plugin-remark-youtube/-/gridsome-plugin-remark-youtube-1.0.1.tgz",
@@ -5758,6 +5800,11 @@
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz",
       "integrity": "sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ=="
     },
+    "hast-util-parse-selector": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
+      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ=="
+    },
     "hast-util-sanitize": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-1.3.1.tgz",
@@ -5794,6 +5841,27 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz",
       "integrity": "sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A=="
+    },
+    "hastscript": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
+      "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+      "requires": {
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0"
+      },
+      "dependencies": {
+        "property-information": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
+          "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
+          "requires": {
+            "xtend": "^4.0.0"
+          }
+        }
+      }
     },
     "he": {
       "version": "1.2.0",
@@ -8742,6 +8810,11 @@
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
+    "prismjs": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
+      "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw=="
+    },
     "probe-image-size": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-4.1.1.tgz",
@@ -9800,31 +9873,12 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shiki": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.1.7.tgz",
-      "integrity": "sha512-9J0PhAdXv6tt3FZf82oKZkcV8c8NRZYJEOH0eIrrxfcyNzMuB79tJFGFSI3OhhiYFL5namob/Ii0Ri4iDoF15A==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.1.tgz",
+      "integrity": "sha512-bC35m7v25bZy7dcuDPdyWOcb8dW9cnqpVXGdHm6Zqn9uPdqIDhV1Hxao7kaSgdMkbDAjLy1E64jhr1L+Lsh5iQ==",
       "requires": {
-        "onigasm": "^2.2.1",
-        "shiki-languages": "^0.1.6",
-        "shiki-themes": "^0.1.7",
-        "vscode-textmate": "git+https://github.com/octref/vscode-textmate.git"
-      }
-    },
-    "shiki-languages": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/shiki-languages/-/shiki-languages-0.1.6.tgz",
-      "integrity": "sha512-rMu+z97UCPKMtPBkzLBItReawXnlOgXZmELFwI/s3ATxd9VzJgSQTtQW/hmW5EYCrzF2kAUjoOnn+50/MPWjgQ==",
-      "requires": {
-        "vscode-textmate": "git+https://github.com/octref/vscode-textmate.git"
-      }
-    },
-    "shiki-themes": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/shiki-themes/-/shiki-themes-0.1.7.tgz",
-      "integrity": "sha512-mpF/VynGun/uNdjOIPnyPv4boN/QYDh+zE94SavgvmatMHkXXjZhls19Xv9rcRwuxUrWfXjaPkEZj7VAk94GGg==",
-      "requires": {
-        "json5": "^2.1.0",
-        "vscode-textmate": "git+https://github.com/octref/vscode-textmate.git"
+        "onigasm": "^2.2.5",
+        "vscode-textmate": "^5.2.0"
       }
     },
     "signal-exit": {
@@ -11509,8 +11563,9 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
     },
     "vscode-textmate": {
-      "version": "git+https://github.com/octref/vscode-textmate.git#e65aabe2227febda7beaad31dd0fca1228c5ddf3",
-      "from": "git+https://github.com/octref/vscode-textmate.git"
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.5.0.tgz",
+      "integrity": "sha512-jToQkPGMNKn0eyKyitYeINJF0NoD240aYyKPIWJv5W2jfPt++jIRg0OSergubtGhbw6SoefkvBYEpX7TsfoSUQ=="
     },
     "vue": {
       "version": "2.6.12",

--- a/package.json
+++ b/package.json
@@ -10,15 +10,16 @@
   "dependencies": {
     "@fullhuman/postcss-purgecss": "1.2.0",
     "@gridsome/plugin-sitemap": "0.2.1",
+    "@gridsome/remark-prismjs": "^0.5.0",
     "@gridsome/source-filesystem": "0.6.2",
     "@gridsome/transformer-remark": "0.6.3",
     "axios": "0.21.2",
     "gridsome": "0.7.22",
-    "gridsome-plugin-remark-shiki": "0.3.0",
     "gridsome-plugin-remark-youtube": "1.0.1",
     "gridsome-plugin-rss": "1.1.0",
     "lodash.pick": "4.4.0",
     "remark-attr": "0.8.3",
+    "shiki": "^0.9.1",
     "vue-fuse": "2.1.0",
     "vue-scrollto": "2.15.0"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,9 @@
 import DefaultLayout from '~/layouts/Default.vue'
 import VueScrollTo from 'vue-scrollto'
 import VueFuse from 'vue-fuse'
+import 'prismjs/themes/prism.css'
+// Prism default CSS about line numbers
+import 'prismjs/plugins/line-numbers/prism-line-numbers.css'
 
 export default function (Vue, { router, head, isClient }) {
   // Set default layout as a global component

--- a/usageDetails/timeseries.md
+++ b/usageDetails/timeseries.md
@@ -9,7 +9,7 @@ targets:
 
 ## Example usage
 
-```sql
+```turtle
 :sensor1    a   brick:Temperature_Sensor ;
     brick:hasUnit unit:DEG_F ;
     brick:timeseries [


### PR DESCRIPTION
Hopefully makes Turtle/SPARQL code blocks a little bit easier to read:

---
**language**: xml:
![image](https://user-images.githubusercontent.com/12209457/168415351-608463f0-9421-4f57-bc5b-cb9744d9607c.png)
**language**: turtle:
![image](https://user-images.githubusercontent.com/12209457/168415568-fd1ca717-f97b-4126-b025-894ab3334f04.png)

---
**language**: none:
![image](https://user-images.githubusercontent.com/12209457/168415609-53bc0e34-7fb1-43f9-a2df-6fa45ed11a21.png)
(makeshift) **language**: sql:
![image](https://user-images.githubusercontent.com/12209457/168415314-63728e1f-81aa-47f2-8530-1a42a6262096.png)
**language**: sparql:
![image](https://user-images.githubusercontent.com/12209457/168415546-fa96ffc9-c95e-4306-a2de-7d2c657aa46f.png)
