### PR TITLE
define the brick namespace for rdflib. not sure why this worked before?

### DIFF
--- a/util.py
+++ b/util.py
@@ -77,11 +77,13 @@ def generate_doc_src(doc_spec):
         print(f"[ ] Brick {'v' if version[0] <= '9' else ''}{version}...", end="\r")
         g = Graph()
         SH = Namespace("http://www.w3.org/ns/shacl#")
+        BRICK = Namespace("https://brickschema.org/schema/Brick#")
 
         # Add namespaces used in the queries
         g.bind("skos", SKOS)
         g.bind("owl", OWL)
         g.bind("sh", SH)
+        g.bind("brick", BRICK)
 
         for directory in doc_spec[version]["input"]:
             for root, dirs, files in os.walk(directory):


### PR DESCRIPTION
generate_doc_src.py fails without this, specifically the query in util.py around line 105
```python
        root_classes = g.query(
            """SELECT DISTINCT ?iri WHERE {
             ?iri rdfs:subClassOf brick:Class .
             FILTER NOT EXISTS {
                ?iri a sh:NodeShape .
                FILTER ( %s )
             }
         }"""
            % (ns_restriction_str("?something"))
```

Brick 1.1 onwards define the brick: namespace in their .ttl file, but 1.0.3 never defines brick: so the query blows up on 1.0.3. I don't understand how this query has been working before - maybe RDFlib didn't care that it was missing? 

I also don't understand how this works on the netlify PR deploy setup
